### PR TITLE
V1.2.0 cluster

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -16,6 +16,7 @@ The first time brooce runs, it will create a `~/.brooce` dir in your home direct
     "username": "admin",
     "password": "eoioszzi",
     "no_auth": false,
+    "no_log": false,
     "disable": false
   },
   "file_output_log": {
@@ -63,6 +64,9 @@ We generate random login credentials the first time you run brooce, but you can 
  
 ### `web.no_auth`
 To run the web server with no authentication, leave username/password (above) blank, and set this to true. This is not recommended if you're having the web server listen on an internet-connected IP.
+ 
+### `web.no_log`
+By default, web interface access is logged to `~/.brooce/web.log`. Set this to true to disable web access logging.
  
 ### `web.disable`
 Set to true to disable the web server.

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -32,6 +32,9 @@ The first time brooce runs, it will create a `~/.brooce` dir in your home direct
     "command": "",
     "time": 0
   },
+  "requeue": {
+    "interval": 60
+  },
   "queues": [
     {
       "name": "common",
@@ -82,6 +85,9 @@ The db which will be used by brooce on your redis server. Defaults to 0.
 
 ### `suicide.enable` / `suicide.command` / `suicide.time`
 For example, if you enabled suicide and set command to `"sudo shutdown -h now"` and time to `600`, you could shutdown your server after there haven't been any jobs for some time. Useful for shutting down idle EC2 instances. Keep in mind that the brooce program will need to have proper permissions to execute the given command, without additional prompts for passwords.
+
+### `requeue.interval`
+The interval in seconds which will be used on requeueing delayed jobs. Defaults to 60.
 
 ### `queues`
 Brooce is multithreaded, and can listen for commands on multiple queues. For example, you could do the following to run 5 threads on the common queue and 2 more threads on the rare queue.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ I've been personally relying on brooce with great results! If you try it out, I 
 Brooce uses redis as its database. Redis can be accessed from any programming language, but how to do it for each one is beyond the scope of this documentation. All of our examples will use the redis-cli shell commands, and it's up to you to substitute the equavalents in your language of choice! If you're a programmer and you haven't learned redis yet, you owe it to yourself to do so!
 
 ## Quick Start
-Just a few commands will download bruce and get it running:
+Just a few commands will download brooce and get it running:
 ```shell
 sudo apt-get install redis-server
 wget https://github.com/SergeyTsalkov/brooce/releases/download/v1.1.0/brooce-linux -O brooce
@@ -214,7 +214,7 @@ redis-cli HSET "brooce:cron:jobs" "daily-biller" "0 */12 * * * queue:common ~/bi
 redis-cli HSET "brooce:cron:jobs" "log-rotate" "0,15,30,45 0-8 * * * queue:common ~/bin/rotate-logs.sh"
 
 # I have no idea why you'd want to do this
-redis-cli HSET "brooce:cron:jobs" "log-rotate" "0-15,45-59 */3,*/4 * * * queue:common ~/bin/delete-customer-data.sh"
+redis-cli HSET "brooce:cron:jobs" "delete-data" "0-15,45-59 */3,*/4 * * * queue:common ~/bin/delete-customer-data.sh"
 ```
 
 ### Storing Cron Jobs in your Git Repo

--- a/src/brooce/config/config.go
+++ b/src/brooce/config/config.go
@@ -28,6 +28,7 @@ type ConfigType struct {
 		Username string `json:"username"`
 		Password string `json:"password"`
 		NoAuth   bool   `json:"no_auth"`
+		NoLog    bool   `json:"no_log"`
 		Disable  bool   `json:"disable"`
 	} `json:"web"`
 

--- a/src/brooce/config/config.go
+++ b/src/brooce/config/config.go
@@ -48,6 +48,10 @@ type ConfigType struct {
 		Time    int    `json:"time"`
 	} `json:"suicide"`
 
+	Requeue struct {
+		Interval int `json:"interval"`
+	} `json:"requeue"`
+
 	Queues []Queue `json:"queues"`
 
 	Path string `json:"path"`
@@ -161,9 +165,13 @@ func initDefaultConfig() {
 			Config.Suicide.Command = "sudo shutdown -h now"
 		}
 
-		if Config.Suicide.Time == 0 {
+		if Config.Suicide.Time <= 0 {
 			Config.Suicide.Time = 600
 		}
+	}
+
+	if Config.Requeue.Interval <= 0 {
+		Config.Requeue.Interval = 60
 	}
 
 	if Config.Path != "" {

--- a/src/brooce/redis/redis-cluster.go
+++ b/src/brooce/redis/redis-cluster.go
@@ -1,4 +1,4 @@
-// +build !cluster
+// +build cluster
 
 package redis
 
@@ -6,21 +6,22 @@ import (
 	"log"
 	"sync"
 	"time"
+	"strings"
 
 	"brooce/config"
 
 	"github.com/go-redis/redis"
 )
 
-var redisClient *redis.Client
+var redisClient *redis.ClusterClient
 var once sync.Once
 
-func Get() *redis.Client {
+func Get() *redis.ClusterClient {
 	once.Do(func() {
 		threads := len(config.Threads) + 10
 
-		redisClient = redis.NewClient(&redis.Options{
-			Addr:         config.Config.Redis.Host,
+		redisClient = redis.NewClusterClient(&redis.ClusterOptions{
+			Addrs:        strings.Split(config.Config.Redis.Host, ","),
 			Password:     config.Config.Redis.Password,
 			MaxRetries:   10,
 			PoolSize:     threads,
@@ -28,7 +29,6 @@ func Get() *redis.Client {
 			ReadTimeout:  30 * time.Second,
 			WriteTimeout: 5 * time.Second,
 			PoolTimeout:  1 * time.Second,
-			DB:           config.Config.Redis.DB,
 		})
 
 		for {

--- a/src/brooce/requeue/requeue.go
+++ b/src/brooce/requeue/requeue.go
@@ -11,11 +11,12 @@ import (
 )
 
 var redisHeader = config.Config.ClusterName
+var requeueInterval = config.Config.Requeue.Interval
 
 func Start() {
 	go func() {
 		for {
-			util.SleepUntilNextMinute()
+			util.SleepUntilNextInterval(requeueInterval)
 			err := requeue()
 			if err != nil {
 				log.Println("Error trying to requeue delayed jobs:", err)

--- a/src/brooce/util/util.go
+++ b/src/brooce/util/util.go
@@ -12,13 +12,17 @@ import (
 	"time"
 )
 
-func SleepUntilNextMinute() {
+func SleepUntilNextInterval(interval int) {
 	now := time.Now().Unix()
-	last_minute := now - now%60
-	next_minute := last_minute + 60
-	sleep_for := next_minute - now
+	last_interval := now - now % int64(interval)
+	next_interval := last_interval + int64(interval)
+	sleep_for := next_interval - now
 
 	time.Sleep(time.Duration(sleep_for) * time.Second)
+}
+
+func SleepUntilNextMinute() {
+	SleepUntilNextInterval(60)
 }
 
 func Md5sum(data interface{}) string {

--- a/src/brooce/web/web.go
+++ b/src/brooce/web/web.go
@@ -84,12 +84,14 @@ func Start() {
 	go func() {
 		var err error
 
-		filename := filepath.Join(config.BrooceDir, "web.log")
-		webLogWriter, err = os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-		if err != nil {
-			log.Fatalln("Unable to open logfile", filename, "for writing! Error was", err)
+		if !config.Config.Web.NoLog {
+			filename := filepath.Join(config.BrooceDir, "web.log")
+			webLogWriter, err = os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+			if err != nil {
+				log.Fatalln("Unable to open logfile", filename, "for writing! Error was", err)
+			}
+			defer webLogWriter.Close()
 		}
-		defer webLogWriter.Close()
 
 		if config.Config.Web.CertFile == "" && config.Config.Web.KeyFile == "" {
 			log.Println("Starting HTTP server on", config.Config.Web.Addr)


### PR DESCRIPTION
Simple go build tag to use brooce on cluster mode redis deployments (cluster name must be hash tagged in config, to avoid cross slot problems), and some configuration improvements.

Please review, and merge it as you wish.
